### PR TITLE
fix: 修复 AI 智能抠图的画笔大小和硬度调节无效问题

### DIFF
--- a/src/components/business/image-cutout/ImageExtraction/index.vue
+++ b/src/components/business/image-cutout/ImageExtraction/index.vue
@@ -83,8 +83,8 @@ let mattingParam: MattingType | null
 const mattingStart = (mattingOptions: MattingType) => {
   mattingOptions.initLoadImages(props.raw, props.result)
   state.isErasing = mattingOptions.isErasing
-  state.radius = Number(mattingOptions.radius)
-  state.hardness = Number(mattingOptions.hardness)
+  state.radius = mattingOptions.radius as number;
+  state.hardness = mattingOptions.hardness as number;
   state.constants = mattingOptions.constants
   mattingParam = mattingOptions
 }


### PR DESCRIPTION
![image](https://github.com/palxiao/poster-design/assets/11418363/0540c58f-1ebd-444f-ad7f-1a634e6853b1)
