### PR TITLE
fix: 🐛 保存模版时候，prevent 为undefined 导致puppeteer 超时

### DIFF
--- a/service/src/utils/download-single.ts
+++ b/service/src/utils/download-single.ts
@@ -67,7 +67,7 @@ const saveScreenshot = async (url: string, { path, width, height, thumbPath, siz
       devices && (await page.emulate(devices))
     }
     // 自动模式下页面加载完毕立即截图
-    if (prevent === false) {
+    if (!prevent) {
       page.on('load', async () => {
         await autoScroll()
         await sleep(wait)


### PR DESCRIPTION
## 复现问题：
> 点击保存按钮， 超时
![image](https://github.com/user-attachments/assets/ae1ff743-8b96-4ea3-ba4e-389d6daa5cf5)
在代码 https://github.com/palxiao/poster-design/blob/4104fafe5213192ef8ee942a9f4ce271caff5753/service/src/service/screenshots.ts#L46C16-L46C30

没有传入 prevent 参数导致
